### PR TITLE
Fix issue2380 insufficient args in parameter formatter

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,15 +67,12 @@ class ParameterFormatterTest {
         }
     }
 
-    @ParameterizedTest
-    @CsvSource({"1,foo {}", "2,bar {}{}"})
-    void format_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
-        final int argCount = placeholderCount - 1;
-        assertThatThrownBy(() -> ParameterFormatter.format(pattern, new Object[argCount], argCount))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "found %d argument placeholders, but provided %d for pattern `%s`",
-                        placeholderCount, argCount, pattern);
+    @Test
+    void formatWithInsufficientArgs() {
+        final String pattern = "Test message {}-{} {}";
+        final Object[] args = {"a", "b"};
+        final String message = ParameterFormatter.format(pattern, args, args.length);
+        assertThat(message).isEqualTo("Test message a-b {}");
     }
 
     @ParameterizedTest

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -197,5 +197,4 @@ class ParameterizedMessageTest {
         final String message = ParameterizedMessage.format(pattern, args);
         assertThat(message).isEqualTo("Test message a-b {}");
     }
-
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -19,12 +19,7 @@ package org.apache.logging.log4j.message;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.test.ListStatusListener;
 import org.apache.logging.log4j.test.junit.Mutable;
 import org.apache.logging.log4j.test.junit.SerialUtil;
@@ -185,50 +180,22 @@ class ParameterizedMessageTest {
         assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
     }
 
-    static Stream<Object[]> testCasesForInsufficientFormatArgs() {
-        return Stream.of(new Object[] {1, "foo {}"}, new Object[] {2, "bar {}{}"});
+    @Test
+    void formatToWithInsufficientArgs() {
+        final String pattern = "Test message {}-{} {}";
+        final Object[] args = {"a", "b"};
+        final ParameterizedMessage message = new ParameterizedMessage(pattern, args);
+        final StringBuilder buffer = new StringBuilder();
+        message.formatTo(buffer);
+        assertThat(buffer.toString()).isEqualTo("Test message a-b {}");
     }
 
-    @ParameterizedTest
-    @MethodSource("testCasesForInsufficientFormatArgs")
-    void formatTo_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
-        final int argCount = placeholderCount - 1;
-        verifyFormattingFailureOnInsufficientArgs(placeholderCount, pattern, argCount, () -> {
-            final ParameterizedMessage message = new ParameterizedMessage(pattern, new Object[argCount]);
-            final StringBuilder buffer = new StringBuilder();
-            message.formatTo(buffer);
-            return buffer.toString();
-        });
+    @Test
+    void formatWithInsufficientArgs() {
+        final String pattern = "Test message {}-{} {}";
+        final Object[] args = {"a", "b"};
+        final String message = ParameterizedMessage.format(pattern, args);
+        assertThat(message).isEqualTo("Test message a-b {}");
     }
 
-    @ParameterizedTest
-    @MethodSource("testCasesForInsufficientFormatArgs")
-    void format_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
-        final int argCount = placeholderCount - 1;
-        verifyFormattingFailureOnInsufficientArgs(
-                placeholderCount, pattern, argCount, () -> ParameterizedMessage.format(pattern, new Object[argCount]));
-    }
-
-    private void verifyFormattingFailureOnInsufficientArgs(
-            final int placeholderCount,
-            final String pattern,
-            final int argCount,
-            final Supplier<String> formattedMessageSupplier) {
-
-        // Verify the formatted message
-        final String formattedMessage = formattedMessageSupplier.get();
-        assertThat(formattedMessage).isEqualTo(pattern);
-
-        // Verify the logged failure
-        final List<StatusData> statusDataList = statusListener.getStatusData().collect(Collectors.toList());
-        assertThat(statusDataList).hasSize(1);
-        final StatusData statusData = statusDataList.get(0);
-        assertThat(statusData.getLevel()).isEqualTo(Level.ERROR);
-        assertThat(statusData.getMessage().getFormattedMessage()).isEqualTo("Unable to format msg: %s", pattern);
-        assertThat(statusData.getThrowable())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "found %d argument placeholders, but provided %d for pattern `%s`",
-                        placeholderCount, argCount, pattern);
-    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -240,14 +240,6 @@ final class ParameterFormatter {
             return;
         }
 
-        // Fail if there are insufficient arguments
-        if (analysis.placeholderCount > args.length) {
-            final String message = String.format(
-                    "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount, args.length, pattern);
-            throw new IllegalArgumentException(message);
-        }
-
         // Fast-path for patterns containing no escapes
         if (analysis.escapedCharFound) {
             formatMessageContainingEscapes(buffer, pattern, args, argCount, analysis);


### PR DESCRIPTION
Fix issue2380 insufficient args in parameter formatter.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
