### PR TITLE
Fix issue 2380: Log messages with insufficient parameters should not throw exception.

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,15 +67,12 @@ class ParameterFormatterTest {
         }
     }
 
-    @ParameterizedTest
-    @CsvSource({"1,foo {}", "2,bar {}{}"})
-    void format_should_fail_on_insufficient_args(final int placeholderCount, final String pattern) {
-        final int argCount = placeholderCount - 1;
-        assertThatThrownBy(() -> ParameterFormatter.format(pattern, new Object[argCount], argCount))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "found %d argument placeholders, but provided %d for pattern `%s`",
-                        placeholderCount, argCount, pattern);
+    @Test
+    void formatWithInsufficientArgs() {
+        final String pattern = "Test message {}-{} {}";
+        final Object[] args = {"a", "b"};
+        final String message = ParameterFormatter.format(pattern, args, args.length);
+        assertThat(message).isEqualTo("Test message a-b {}");
     }
 
     @ParameterizedTest

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -240,14 +240,6 @@ final class ParameterFormatter {
             return;
         }
 
-        // Fail if there are insufficient arguments
-        if (analysis.placeholderCount > args.length) {
-            final String message = String.format(
-                    "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount, args.length, pattern);
-            throw new IllegalArgumentException(message);
-        }
-
         // Fast-path for patterns containing no escapes
         if (analysis.escapedCharFound) {
             formatMessageContainingEscapes(buffer, pattern, args, argCount, analysis);

--- a/src/changelog/.2.x.x/fix_2380_insufficient_args_in_ParameterFormatter.xml
+++ b/src/changelog/.2.x.x/fix_2380_insufficient_args_in_ParameterFormatter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <issue id="2380" link="https://github.com/apache/logging-log4j2/pull/2380"/>
+  <description format="asciidoc">
+    Fix that parameterized message formatting throws an exception when there are insufficient number of parameters.
+    It previously simply didn't replace the '{}' sequence. The behavior changed in 2.21.0 and should be restored for backward compatibility.
+  </description>
+</entry>


### PR DESCRIPTION
Fix issue 2380: Log messages with insufficient parameters should not throw exception.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
